### PR TITLE
Simple directory datasource

### DIFF
--- a/examples/directory/config.tf
+++ b/examples/directory/config.tf
@@ -12,7 +12,9 @@ provider "linux" {
   private_key = file("../../ssh-keys/id_rsa")
 }
 
-data "linux_directory" "test" {}
+data "linux_directory" "test" {
+  path = "/test"
+}
 
 output "test" {
   value = data.linux_directory.test

--- a/examples/directory/config.tf
+++ b/examples/directory/config.tf
@@ -13,3 +13,7 @@ provider "linux" {
 }
 
 data "linux_directory" "test" {}
+
+output "test" {
+  value = data.linux_directory.test
+}

--- a/examples/directory/config.tf
+++ b/examples/directory/config.tf
@@ -13,7 +13,7 @@ provider "linux" {
 }
 
 data "linux_directory" "test" {
-  path = "/test"
+  path = "/etc"
 }
 
 output "test" {

--- a/examples/directory/config.tf
+++ b/examples/directory/config.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    linux = {
+      source = "beleap/linux"
+    }
+  }
+}
+
+provider "linux" {
+  host        = "node01.titanv.exp.riiid.cloud"
+  username    = "root"
+  private_key = file("../../ssh-keys/id_rsa")
+}
+
+data "linux_directory" "test" {}

--- a/internal/directory/common.go
+++ b/internal/directory/common.go
@@ -22,7 +22,7 @@ func NewLinuxDirectoryModel(linuxDirectory *LinuxDirectory) LinuxDirectoryModel 
 }
 
 func Get(linuxCtx util.LinuxContext, path string) (*LinuxDirectory, *util.CommonError) {
-	_, commonError := sshUtil.RunCommand(linuxCtx, "get facl"+" "+path, nil)
+	_, commonError := sshUtil.RunCommand(linuxCtx, "getfacl"+" "+path, nil)
 	if commonError != nil {
 		return nil, commonError
 	}

--- a/internal/directory/common.go
+++ b/internal/directory/common.go
@@ -1,0 +1,32 @@
+package directory
+
+import (
+	"terraform-provider-linux/internal/util"
+	sshUtil "terraform-provider-linux/internal/util/ssh"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type LinuxDirectory struct {
+	Path string
+}
+
+type LinuxDirectoryModel struct {
+	Path types.String `tfsdk:"path"`
+}
+
+func NewLinuxDirectoryModel(linuxDirectory *LinuxDirectory) LinuxDirectoryModel {
+	return LinuxDirectoryModel{
+		Path: types.StringValue(linuxDirectory.Path),
+	}
+}
+
+func Get(linuxCtx util.LinuxContext, path string) (*LinuxDirectory, *util.CommonError) {
+	_, commonError := sshUtil.RunCommand(linuxCtx, "get facl"+" "+path, nil)
+	if commonError != nil {
+		return nil, commonError
+	}
+	return &LinuxDirectory{
+		Path: path,
+	}, nil
+}

--- a/internal/directory/data_source.go
+++ b/internal/directory/data_source.go
@@ -11,7 +11,8 @@ import (
 )
 
 var (
-	_ datasource.DataSource = &directoryDataSource{}
+	_ datasource.DataSource              = &directoryDataSource{}
+	_ datasource.DataSourceWithConfigure = &directoryDataSource{}
 )
 
 func NewDirectoryDataSource() datasource.DataSource {
@@ -20,6 +21,11 @@ func NewDirectoryDataSource() datasource.DataSource {
 
 type directoryDataSource struct {
 	client *goph.Client
+}
+
+// Configure implements datasource.DataSourceWithConfigure.
+func (*directoryDataSource) Configure(context.Context, datasource.ConfigureRequest, *datasource.ConfigureResponse) {
+	panic("unimplemented")
 }
 
 // Metadata implements datasource.DataSource.

--- a/internal/directory/data_source.go
+++ b/internal/directory/data_source.go
@@ -1,0 +1,35 @@
+package directory
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/melbahja/goph"
+)
+
+var (
+	_ datasource.DataSource = &directoryDataSource{}
+)
+
+func NewDirectoryDataSource() datasource.DataSource {
+	return &directoryDataSource{}
+}
+
+type directoryDataSource struct {
+	client *goph.Client
+}
+
+// Metadata implements datasource.DataSource.
+func (*directoryDataSource) Metadata(context.Context, datasource.MetadataRequest, *datasource.MetadataResponse) {
+	panic("unimplemented")
+}
+
+// Read implements datasource.DataSource.
+func (*directoryDataSource) Read(context.Context, datasource.ReadRequest, *datasource.ReadResponse) {
+	panic("unimplemented")
+}
+
+// Schema implements datasource.DataSource.
+func (*directoryDataSource) Schema(context.Context, datasource.SchemaRequest, *datasource.SchemaResponse) {
+	panic("unimplemented")
+}

--- a/internal/directory/data_source.go
+++ b/internal/directory/data_source.go
@@ -32,8 +32,8 @@ func (d *directoryDataSource) Configure(_ context.Context, req datasource.Config
 	client, ok := req.ProviderData.(*goph.Client)
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
-			"Unexpected Data Source Configure Type",
+			"ProviderData type assertion failed",
+			"Expected ProviderData to be *goph.Client, got different type",
 		)
 		return
 	}
@@ -63,7 +63,7 @@ func (d *directoryDataSource) Read(ctx context.Context, req datasource.ReadReque
 		resp.Diagnostics.AddAttributeError(
 			path.Root("path"),
 			"Wrong path",
-			"Wrong path",
+			"Invalid or unknown path provided",
 		)
 		return
 	}
@@ -73,7 +73,7 @@ func (d *directoryDataSource) Read(ctx context.Context, req datasource.ReadReque
 		resp.Diagnostics.AddAttributeError(
 			path.Root("path"),
 			"Empty path is not allowed",
-			"Please speicfy path",
+			"Please specify a valid path",
 		)
 		return
 	}

--- a/internal/directory/data_source.go
+++ b/internal/directory/data_source.go
@@ -24,8 +24,21 @@ type directoryDataSource struct {
 }
 
 // Configure implements datasource.DataSourceWithConfigure.
-func (*directoryDataSource) Configure(context.Context, datasource.ConfigureRequest, *datasource.ConfigureResponse) {
-	panic("unimplemented")
+func (d *directoryDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*goph.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			"Unexpected Data Source Configure Type",
+		)
+		return
+	}
+
+	d.client = client
 }
 
 // Metadata implements datasource.DataSource.

--- a/internal/directory/data_source.go
+++ b/internal/directory/data_source.go
@@ -20,8 +20,8 @@ type directoryDataSource struct {
 }
 
 // Metadata implements datasource.DataSource.
-func (*directoryDataSource) Metadata(context.Context, datasource.MetadataRequest, *datasource.MetadataResponse) {
-	panic("unimplemented")
+func (*directoryDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_directory"
 }
 
 // Read implements datasource.DataSource.

--- a/internal/directory/data_source.go
+++ b/internal/directory/data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/melbahja/goph"
 )
 
@@ -30,6 +31,12 @@ func (*directoryDataSource) Read(context.Context, datasource.ReadRequest, *datas
 }
 
 // Schema implements datasource.DataSource.
-func (*directoryDataSource) Schema(context.Context, datasource.SchemaRequest, *datasource.SchemaResponse) {
-	panic("unimplemented")
+func (*directoryDataSource) Schema(_ context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"path": schema.StringAttribute{
+				Required: true,
+			},
+		},
+	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"context"
+	"terraform-provider-linux/internal/directory"
 	"terraform-provider-linux/internal/user"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -162,6 +163,7 @@ func (p *LinuxProvider) Configure(ctx context.Context, req provider.ConfigureReq
 func (p *LinuxProvider) DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
 		user.NewUserDataSource,
+		directory.NewDirectoryDataSource,
 	}
 }
 


### PR DESCRIPTION
- init dummy data source
- add example
- add output
- add metadata
- add minimal schema
- update example
- add simple read
- create configure
- implement configure
- fix typo in command
- update path to existing one


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a Terraform configuration for interacting with Linux systems, including data retrieval from directories.
  - Added a new data source in the Terraform provider to support fetching information about Linux directories.

- **Documentation**
  - Updated documentation to reflect the new data source and its usage within Terraform configurations.

- **Refactor**
  - Implemented a new internal structure for managing Linux directory information within the provider codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->